### PR TITLE
Ages: Prevent softlock when exiting Maku Road without shovel

### DIFF
--- a/asm/layouts.yaml
+++ b/asm/layouts.yaml
@@ -205,6 +205,8 @@ ages:
       db 01,a5,00,45,0b # cont.
       db 01,a5,00,55,6c # cont.
       db 00,83,00,44,d7 # portal outside D2 present
+      db 01,48,00,31,15 # past maku road: remove dirt when exiting
+      db 01,48,02,31,cd # cont.
       db ff
 
   # burning the first tree in yoll graveyard should set room flag 1 so that it

--- a/asm/layouts.yaml
+++ b/asm/layouts.yaml
@@ -205,8 +205,7 @@ ages:
       db 01,a5,00,45,0b # cont.
       db 01,a5,00,55,6c # cont.
       db 00,83,00,44,d7 # portal outside D2 present
-      db 01,48,00,31,15 # past maku road: remove dirt when exiting
-      db 01,48,02,31,cd # cont.
+      db 01,48,02,31,cd # past maku road: remove dirt when exiting
       db ff
 
   # burning the first tree in yoll graveyard should set room flag 1 so that it
@@ -256,3 +255,7 @@ ages:
   # put a "return bush" for long hook across from syrup's shop.
   23/7ea0/: db 27,c8
   23/7ead/: db 22
+
+  # Maku Path: Prevent Softlock when exiting cave (see tileSubTable)
+  25/5c9a/: db 15
+  26/4a9e/: db 15

--- a/asm/warps.yaml
+++ b/asm/warps.yaml
@@ -21,7 +21,15 @@ ages:
       ret
       .next
       push bc
-      ld bc,5605
+      ld bc,0d04 # past maku road south entrance room
+      call compareRoom
+      jr nz,.notMaku
+      push hl
+      ld hl,c848 # room flags outside past maku road
+      set 1,(hl)
+      pop hl
+      .notMaku
+      ld bc,5605 # d7 entrance room
       call compareRoom
       jr nz,.notJabu
       ld a,21


### PR DESCRIPTION
Since Keysanity allows the player to backdoor past Maku Road including the keydoor, they could also leave it through the south exit - even without shovel.

Similar to the water reset on exiting D7, I adjusted the code to set a room flag for the outside room which removes the dirt when set.

~~(I haven't checked if one of the tileSubTable entries could be saved by a static replacement, considering the amout of dirt piles on that screen I have my doubts.)~~

Image of how it looks like exiting the cave:
![makuroad](https://user-images.githubusercontent.com/1953510/71636545-30fb8b80-2c32-11ea-9264-4bda30739ea3.png)
